### PR TITLE
Refactor and redesign library

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -7,3 +7,39 @@
 This is a library that enables handling and manipulation of Salesforce 
 Identifiers. Specifically it enables converting identifiers between 15 
 character (case-sensitive) and 18 character (case-insensitive) versions.
+
+This library lazily parses a Salesforce identifier for the user and provides 
+other convenience methods for handling portions of the identifier.
+
+## Examples
+
+It's possible to have different versions of a Salesforce identifier. 15 
+character identifiers are case-sensitive while 18 character identifers are 
+not. As a result, this library always checks and adjusts the casing of 
+identifiers and always produces 18 character identifiers. This allows users to 
+confidently use which ever form they prefer.
+
+```go
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/sigmavirus24/salesforceid"
+)
+
+func main() {
+	// Note that we're using an 18-character, entirely lower-cased Salesforce identifier here
+	sfid, err := salesforceid.New("00d000000000062eaa")
+	if err != nil {
+		fmt.Printf("encountered unexpected error: %q", err)
+		os.Exit(1)
+	}
+	fmt.Println(sfid)
+}
+```
+
+Furthermore, one can use this library to perform arithmetic on the 
+identifiers. For an example of where this might be useful see the 
+[example](./example_test.go) in this project.

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,43 @@
+package salesforceid_test
+
+import (
+	"fmt"
+
+	sfid "github.com/sigmavirus24/salesforceid"
+)
+
+func GenerateChunks(starting *sfid.SalesforceID, chunkSize uint64) func() (*sfid.SalesforceID, *sfid.SalesforceID) {
+	next := starting
+	return func() (*sfid.SalesforceID, *sfid.SalesforceID) {
+		current := next
+		end, _ := current.Add(chunkSize)
+		next, _ = end.Add(1)
+		return current, end
+	}
+}
+
+func Example() {
+	s, _ := sfid.New("001000000000000")
+	chunker := GenerateChunks(s, 250000)
+
+	for i := 0; i < 15; i++ {
+		start, end := chunker()
+		fmt.Printf("SELECT Id FROM Account WHERE Id >= %s AND Id <= %s\n", start, end)
+	}
+	// Output:
+	// SELECT Id FROM Account WHERE Id >= 001000000000000AAA AND Id <= 00100000000132GAAQ
+	// SELECT Id FROM Account WHERE Id >= 00100000000132HAAQ AND Id <= 00100000000264XAAQ
+	// SELECT Id FROM Account WHERE Id >= 00100000000264YAAQ AND Id <= 00100000000396oAAA
+	// SELECT Id FROM Account WHERE Id >= 00100000000396pAAA AND Id <= 001000000004C95AAE
+	// SELECT Id FROM Account WHERE Id >= 001000000004C96AAE AND Id <= 001000000005FBMAA2
+	// SELECT Id FROM Account WHERE Id >= 001000000005FBNAA2 AND Id <= 001000000006IDdAAM
+	// SELECT Id FROM Account WHERE Id >= 001000000006IDeAAM AND Id <= 001000000007LFuAAM
+	// SELECT Id FROM Account WHERE Id >= 001000000007LFvAAM AND Id <= 001000000008OIBAA2
+	// SELECT Id FROM Account WHERE Id >= 001000000008OICAA2 AND Id <= 001000000009RKSAA2
+	// SELECT Id FROM Account WHERE Id >= 001000000009RKTAA2 AND Id <= 00100000000AUMjAAO
+	// SELECT Id FROM Account WHERE Id >= 00100000000AUMkAAO AND Id <= 00100000000BXP0AAO
+	// SELECT Id FROM Account WHERE Id >= 00100000000BXP1AAO AND Id <= 00100000000CaRHAA0
+	// SELECT Id FROM Account WHERE Id >= 00100000000CaRIAA0 AND Id <= 00100000000DdTYAA0
+	// SELECT Id FROM Account WHERE Id >= 00100000000DdTZAA0 AND Id <= 00100000000EgVpAAK
+	// SELECT Id FROM Account WHERE Id >= 00100000000EgVqAAK AND Id <= 00100000000FjY6AAK
+}

--- a/salesforceid_test.go
+++ b/salesforceid_test.go
@@ -1,11 +1,13 @@
-package salesforceid
+package salesforceid_test
 
 import (
 	"fmt"
 	"testing"
+
+	"github.com/sigmavirus24/salesforceid"
 )
 
-func TestTo18(t *testing.T) {
+func TestNew(t *testing.T) {
 	testCases := []struct {
 		sfid        string
 		expected    string
@@ -15,6 +17,7 @@ func TestTo18(t *testing.T) {
 		{"00D000000000062EAA", "00D000000000062EAA", false, nil},
 		{"00D000000000062", "00D000000000062EAA", false, nil},
 		{"00d000000000062", "00d000000000062AAA", false, nil},
+		{"00d000000000062eaa", "00D000000000062EAA", false, nil},
 		{"003D0000001aH2A", "003D0000001aH2AIAU", false, nil},
 		{"0a3D0000001aH2A", "0a3D0000001aH2AIAU", false, nil},
 		{"0A3D0000001aH2A", "0A3D0000001aH2AKAU", false, nil},
@@ -25,15 +28,21 @@ func TestTo18(t *testing.T) {
 		{"zzzzzzzzzzzzzzz", "zzzzzzzzzzzzzzzAAA", false, nil},
 		{"AAAAAAAAAAAAAAA", "AAAAAAAAAAAAAAA555", false, nil},
 		{"ZZZZZZZZZZZZZZZ", "ZZZZZZZZZZZZZZZ555", false, nil},
-		{"ZZZZZZZZZZZZZZ", "", true, ErrInvalidLengthSFID},
-		{"ZZZZZZZZZZZZZZZZ", "", true, ErrInvalidLengthSFID},
+		{"ZZZZZZZZZZZZZZ", "", true, salesforceid.ErrInvalidLengthSFID},   // 14 char sfid
+		{"ZZZZZZZZZZZZZZZZ", "", true, salesforceid.ErrInvalidLengthSFID}, // 16 char sfid
+		{"001000000000062EAA", "", true, salesforceid.ErrInvalidSFID},     // 001 should be 00<cap>
+		{"aaaaaaaaaaaaaaa555", "AAAAAAAAAAAAAAA555", false, nil},
+		{"ZZZZZZZZZZZZZZZ555", "ZZZZZZZZZZZZZZZ555", false, nil},
+		{"zzzzzzzzzzzzzzz555", "ZZZZZZZZZZZZZZZ555", false, nil},
+		{"ZzZzZzZzZZzZZzzAAA", "zzzzzzzzzzzzzzzAAA", false, nil},
+		{"ZZZZZZZZZZZZZZZAAA", "zzzzzzzzzzzzzzzAAA", false, nil},
 	}
 
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.sfid, func(t *testing.T) {
 			t.Parallel()
-			eighteen, err := New(tc.sfid).To18()
+			id, err := salesforceid.New(tc.sfid)
 			if tc.shouldErr && err == nil {
 				t.Errorf("expected error but didn't get an error")
 			}
@@ -43,8 +52,8 @@ func TestTo18(t *testing.T) {
 			if !tc.shouldErr && err != nil {
 				t.Errorf("expected no error but got %q", err)
 			}
-			if eighteen != nil {
-				s := eighteen.String()
+			if id != nil {
+				s := id.String()
 				if tc.expected != s {
 					t.Errorf("expected %s, got %s", tc.expected, s)
 				}
@@ -53,209 +62,47 @@ func TestTo18(t *testing.T) {
 	}
 }
 
-func BenchmarkTo18(b *testing.B) {
-	sfid := New("0a3d0000001ah2a")
-	for i := 0; i < b.N; i++ {
-		_, _ = sfid.To18()
-	}
+func BenchmarkNew(b *testing.B) {
+	b.Run("15 char sfid", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_, _ = salesforceid.New("0a3d0000001ah2a")
+		}
+	})
+	b.Run("18 char sfid", func(b *testing.B) {
+		b.Run("no changes necessary", func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_, _ = salesforceid.New("0A3D0000001aH2AKAU")
+			}
+		})
+		b.Run("everything needs correction", func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_, _ = salesforceid.New("zzzzzzzzzzzzzzz555")
+			}
+		})
+	})
 }
 
-func TestTo15(t *testing.T) {
+func TestAdd(t *testing.T) {
 	testCases := []struct {
 		sfid        string
+		add         uint64
 		expected    string
 		shouldErr   bool
 		expectedErr error
 	}{
-		{"ZZZZZZZZZZZZZZ", "", true, ErrInvalidLengthSFID},
-		{"ZZZZZZZZZZZZZZZZ", "", true, ErrInvalidLengthSFID},
-		{"AAAAAAAAAAAAAAA555", "AAAAAAAAAAAAAAA", false, nil},
-		{"aaaaaaaaaaaaaaa555", "AAAAAAAAAAAAAAA", false, nil},
-		{"ZZZZZZZZZZZZZZZ555", "ZZZZZZZZZZZZZZZ", false, nil},
-		{"zzzzzzzzzzzzzzz555", "ZZZZZZZZZZZZZZZ", false, nil},
-		{"ZzZzZzZzZZzZZzzAAA", "zzzzzzzzzzzzzzz", false, nil},
-		{"ZZZZZZZZZZZZZZZAAA", "zzzzzzzzzzzzzzz", false, nil},
-		{"ZZZZZZZZZZZZZZZ", "ZZZZZZZZZZZZZZZ", false, nil},
-		{"00D000000000062EAA", "00D000000000062", false, nil},
-		{"00d000000000062eaa", "00D000000000062", false, nil},
+		{"001000000000000AAA", 1, "001000000000001AAA", false, nil},
+		{"001000zzzzzzzzzAAA", 1, "", true, salesforceid.ErrInvalidAddition},
+		{"00100000000000zAAA", 1, "001000000000010AAA", false, nil},
+		{"00100000000000zAAA", 238328, "00100000000100zAAA", false, nil},
+		{"001000000000000AAA", 10, "00100000000000AAAQ", false, nil},
 	}
 
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.sfid, func(t *testing.T) {
-			t.Parallel()
-			sfid := New(tc.sfid)
-			fifteen, err := sfid.To15()
-			if tc.shouldErr && err == nil {
-				t.Errorf("expected error but didn't get an error")
-			}
-			if tc.shouldErr && err != tc.expectedErr {
-				t.Errorf("expected err %q, got err %q", tc.expectedErr, err)
-			}
-			if !tc.shouldErr && err != nil {
-				t.Errorf("didn't expect an error but got %q", err)
-			}
-			if fifteen != nil {
-				s := fifteen.String()
-				if tc.expected != s {
-					t.Errorf("expected %s, got %s", tc.expected, s)
-				}
-			}
-		})
-	}
-}
-
-func BenchmarkTo15(b *testing.B) {
-	sfid := New("00d000000000062eaa")
-	for i := 0; i < b.N; i++ {
-		_, _ = sfid.To15()
-	}
-}
-
-func TestNormalize(t *testing.T) {
-	testCases := []struct {
-		sfid        string
-		expected    string
-		shouldErr   bool
-		expectedErr error
-	}{
-		{"00d000000000062eaa", "00D000000000062EAA", false, nil},
-		{"00D000000000062EAA", "00D000000000062EAA", false, nil},
-		{"00D000000000062eaa", "00D000000000062EAA", false, nil},
-		{"00d000000000062EAA", "00D000000000062EAA", false, nil},
-		{"00D000000000062", "00D000000000062EAA", false, nil},
-		{"00D000000000062", "00D000000000062EAA", false, nil},
-		{"003D0000001aH2A", "003D0000001aH2AIAU", false, nil},
-		{"0a3D0000001aH2A", "0a3D0000001aH2AIAU", false, nil},
-		{"0A3D0000001aH2A", "0A3D0000001aH2AKAU", false, nil},
-		{"0a3d0000001ah2a", "0a3d0000001ah2aAAA", false, nil},
-		{"0a3d0000001ah2aa", "", true, ErrInvalidLengthSFID},
-		{"0a3d0000001ah2aaaaa", "", true, ErrInvalidLengthSFID},
-		{"0a3d000000", "", true, ErrInvalidLengthSFID},
-	}
-
-	for _, tc := range testCases {
-		tc := tc
-		t.Run(tc.sfid, func(t *testing.T) {
-			t.Parallel()
-			sfid := New(tc.sfid)
-			normalized, err := sfid.Normalize()
-			if tc.shouldErr && err == nil {
-				t.Errorf("expected error but didn't get an error")
-			}
-			if tc.shouldErr && err != tc.expectedErr {
-				t.Errorf("expected err %q, got err %q", tc.expectedErr, err)
-			}
-			if !tc.shouldErr && err != nil {
-				t.Errorf("expected no error but got %q", err)
-			}
-			if normalized != nil {
-				s := normalized.String()
-				if tc.expected != s {
-					t.Errorf("expected %s, got %s", tc.expected, s)
-				}
-			}
-		})
-	}
-}
-
-func BenchmarkNormalize(b *testing.B) {
-	sfid := New("00d000000000062eaa")
-	for i := 0; i < b.N; i++ {
-		_, _ = sfid.Normalize()
-	}
-}
-
-func TestKeyPrefix(t *testing.T) {
-	testCases := []struct {
-		sfid     string
-		expected string
-	}{
-		{"003D0000001aH2A", "003"},
-		{"0a3D0000001aH2A", "0a3"},
-		{"0A3D0000001aH2A", "0A3"},
-	}
-
-	for _, tc := range testCases {
-		tc := tc
-		t.Run(tc.sfid, func(t *testing.T) {
-			t.Parallel()
-			s := New(tc.sfid)
-			p := s.KeyPrefix()
-			if p != tc.expected {
-				t.Errorf("expected %s, got %s", tc.expected, p)
-			}
-		})
-	}
-}
-
-func BenchmarkKeyPrefix(b *testing.B) {
-	sfid := New("0a3D0000001aH2A")
-	for i := 0; i < b.N; i++ {
-		_ = sfid.KeyPrefix()
-	}
-}
-
-func TestPodIdentifier(t *testing.T) {
-	testCases := []struct {
-		sfid     string
-		expected string
-	}{
-		{"003D0000001aH2A", "003"},
-		{"0a3D0000001aH2A", "0a3"},
-		{"0A3D0000001aH2A", "0A3"},
-	}
-
-	for _, tc := range testCases {
-		tc := tc
-		t.Run(tc.sfid, func(t *testing.T) {
-			t.Parallel()
-			s := New(tc.sfid)
-			p := s.KeyPrefix()
-			if p != tc.expected {
-				t.Errorf("expected %s, got %s", tc.expected, p)
-			}
-		})
-	}
-}
-
-func TestString(t *testing.T) {
-	testCases := []struct {
-		sfid string
-	}{
-		{"003D0000001aH2A"},
-		{"0a3D0000001aH2A"},
-		{"0A3D0000001aH2A"},
-	}
-	for _, tc := range testCases {
-		tc := tc
-		t.Run(tc.sfid, func(t *testing.T) {
-			t.Parallel()
-			s := New(tc.sfid).String()
-			if s != tc.sfid {
-				t.Errorf("expected %s, got %s", tc.sfid, s)
-			}
-		})
-	}
-}
-
-func TestSuffix(t *testing.T) {
-	testCases := []struct {
-		sfid        string
-		expected    string
-		shouldErr   bool
-		expectedErr error
-	}{
-		{"00D000000000062", "", true, ErrNoSuffix},
-		{"00D000000000062EAA", "EAA", false, nil},
-	}
-
-	for _, tc := range testCases {
-		tc := tc
-		t.Run(tc.sfid, func(t *testing.T) {
-			t.Parallel()
-			sfid := New(tc.sfid)
-			suffix, err := sfid.Suffix()
+			want := tc.expected
+			sfid, _ := salesforceid.New(tc.sfid)
+			got, err := sfid.Add(tc.add)
 			if tc.shouldErr && err == nil {
 				t.Errorf("expected error but got nil")
 			}
@@ -265,8 +112,160 @@ func TestSuffix(t *testing.T) {
 			if !tc.shouldErr && err != nil {
 				t.Errorf("didn't expect an error but got %q", err)
 			}
-			if suffix != "" && suffix != tc.expected {
-				t.Errorf("expected suffix %s, got %s", tc.expected, suffix)
+			if got != nil && want != got.String() {
+				t.Errorf("wanted %s, got %s", want, got)
+			}
+		})
+	}
+}
+
+func TestSubtract(t *testing.T) {
+	testCases := []struct {
+		sfid        string
+		sub         uint64
+		expected    string
+		shouldErr   bool
+		expectedErr error
+	}{
+		{"001000000000000AAA", 1, "", true, salesforceid.ErrInvalidSubtraction},
+		{"001000zzzzzzzzzAAA", 1, "001000zzzzzzzzyAAA", false, nil},
+		{"001000000000010AAA", 1, "00100000000000zAAA", false, nil},
+		{"00100000000000aAAA", 1, "00100000000000ZAAQ", false, nil},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.sfid, func(t *testing.T) {
+			want := tc.expected
+			sfid, _ := salesforceid.New(tc.sfid)
+			got, err := sfid.Subtract(tc.sub)
+			if tc.shouldErr && err == nil {
+				t.Errorf("expected error but got nil")
+			}
+			if tc.shouldErr && err != tc.expectedErr {
+				t.Errorf("expected err %q but got %q", tc.expectedErr, err)
+			}
+			if !tc.shouldErr && err != nil {
+				t.Errorf("didn't expect an error but got %q", err)
+			}
+			if got != nil && want != got.String() {
+				t.Errorf("wanted %s, got %s", want, got)
+			}
+		})
+	}
+}
+
+func TestEncode(t *testing.T) {
+	testCases := []struct {
+		i           uint64
+		o           string
+		shouldErr   bool
+		expectedErr error
+	}{
+		// Boundaries
+		{0, "000000000", false, nil},
+		{13537086546263553, "", true, salesforceid.ErrValueTooLarge},
+		// Within boundaries
+		{5, "000000005", false, nil},
+		{15, "00000000F", false, nil},
+		{30, "00000000U", false, nil},
+		{45, "00000000j", false, nil},
+		{61, "00000000z", false, nil},
+		{1024, "0000000GW", false, nil},
+		{10241024, "00000gy9o", false, nil},
+		{6768543273131776, "V00000000", false, nil},
+		{13537086546263552 - 1, "zzzzzzzzz", false, nil},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.o, func(t *testing.T) {
+			want := tc.o
+			got, err := salesforceid.Encode(tc.i)
+			if tc.shouldErr && err == nil {
+				t.Errorf("expected error but got nil")
+			}
+			if tc.shouldErr && err != tc.expectedErr {
+				t.Errorf("expected err %q but got %q", tc.expectedErr, err)
+			}
+			if !tc.shouldErr && err != nil {
+				t.Errorf("didn't expect an error but got %q", err)
+			}
+			if want != got {
+				t.Errorf("wanted \"%s\", got \"%s\"", want, got)
+			}
+		})
+	}
+}
+
+func BenchmarkEncode(b *testing.B) {
+	benchmarks := []struct {
+		name string
+		v    uint64
+	}{
+		{"max value", 13537086546263552 - 1},
+		{"min value", 0},
+		{"middle value", 6768543273131776},
+	}
+	for _, benchmark := range benchmarks {
+		b.Run(benchmark.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_, _ = salesforceid.Encode(benchmark.v)
+			}
+		})
+	}
+}
+
+func TestDecode(t *testing.T) {
+	testCases := []struct {
+		in          string
+		out         uint64
+		shouldErr   bool
+		expectedErr error
+	}{
+		{"00000gy9o", 10241024, false, nil},
+		{"0000000GW", 1024, false, nil},
+		{"000000GW", 0, true, salesforceid.ErrInvalidNumericIdentifier},
+		{"", 0, true, salesforceid.ErrInvalidNumericIdentifier},
+		{"0000000000", 0, true, salesforceid.ErrInvalidNumericIdentifier},
+		{"000000000", 0, false, nil},
+		{"zzzzzzzzz", 13537086546263552 - 1, false, nil}, // 13537086546263552 = 62 ^ 9
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.in, func(t *testing.T) {
+			want := tc.out
+			got, err := salesforceid.Decode([]byte(tc.in))
+			if tc.shouldErr && err == nil {
+				t.Errorf("expected error but got nil")
+			}
+			if tc.shouldErr && err != tc.expectedErr {
+				t.Errorf("expected err %q but got %q", tc.expectedErr, err)
+			}
+			if !tc.shouldErr && err != nil {
+				t.Errorf("didn't expect an error but got %q", err)
+			}
+			if want != got {
+				t.Errorf("wanted %d, got %d", want, got)
+			}
+		})
+	}
+}
+
+func BenchmarkDecode(b *testing.B) {
+	benchmarks := []struct {
+		name string
+		v    string
+	}{
+		{"max value", "zzzzzzzzz"},
+		{"min value", "000000000"},
+		{"middle value", "V00000000"},
+	}
+	for _, benchmark := range benchmarks {
+		b.Run(benchmark.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_, _ = salesforceid.Encode(13537086546263552 - 1)
 			}
 		})
 	}
@@ -274,32 +273,50 @@ func TestSuffix(t *testing.T) {
 
 // Examples
 
-func ExampleSalesforceID_To18() {
-	fifteen := New("00D000000000062")
-	eighteen, err := fifteen.To18()
+func ExampleNew() {
+	id, err := salesforceid.New("00D000000000062")
 	if err != nil {
 		fmt.Println(err)
 	}
-	fmt.Printf("%s => %s", fifteen, eighteen)
+	fmt.Printf("00D000000000062 => %s", id)
 	// Output: 00D000000000062 => 00D000000000062EAA
 }
 
-func ExampleSalesforceID_To15() {
-	eighteen := New("00d000000000062eaa")
-	fifteen, err := eighteen.To15()
+func ExampleNew_second() {
+	id, err := salesforceid.New("00d000000000062eaa")
 	if err != nil {
 		fmt.Println(err)
 	}
-	fmt.Printf("%s => %s", eighteen, fifteen)
-	// Output: 00d000000000062eaa => 00D000000000062
+	fmt.Printf("00d000000000062eaa => %s", id)
+	// Output: 00d000000000062eaa => 00D000000000062EAA
 }
 
-func ExampleSalesforceID_Normalize() {
-	fifteen := New("00D000000000062")
-	normalized, err := fifteen.Normalize()
-	if err != nil {
-		fmt.Println(err)
-	}
-	fmt.Printf("%s => %s", fifteen, normalized)
-	// Output: 00D000000000062 => 00D000000000062EAA
+func ExampleDecode() {
+	id, _ := salesforceid.New("00D000000000062")
+	val, _ := salesforceid.Decode(id.NumericIdentifier)
+	fmt.Printf("%s == %d", string(id.NumericIdentifier), val)
+	// Output: 000000062 == 374
+}
+
+func ExampleDecode_second() {
+	id, _ := salesforceid.New("00d000000000062eaa")
+	val, _ := salesforceid.Decode(id.NumericIdentifier)
+	fmt.Printf("%s == %d", string(id.NumericIdentifier), val)
+	// Output: 000000062 == 374
+}
+
+func ExampleEncode() {
+	id, _ := salesforceid.New("00d000000000062eaa")
+	val, _ := salesforceid.Decode(id.NumericIdentifier)
+	encoded, _ := salesforceid.Encode(val + 238328) // 238328 == 62 * 62 * 62
+	fmt.Printf("%s + 238328 == %s", string(id.NumericIdentifier), encoded)
+	// Output: 000000062 + 238328 == 000001062
+}
+
+func ExampleEncode_second() {
+	id, _ := salesforceid.New("00d000000000062eaa")
+	val, _ := salesforceid.Decode(id.NumericIdentifier)
+	encoded, _ := salesforceid.Encode(val)
+	fmt.Printf("%s == %s", string(id.NumericIdentifier), encoded)
+	// Output: 000000062 == 000000062
 }


### PR DESCRIPTION
Let's make things error sooner rather than later and have some
assurances that the identifiers are valid-ish when we create them. This
also removes the unnecessary interface and provides only Add/Subtract
methods on the identifier.